### PR TITLE
Build the docker image from the latest Ubuntu

### DIFF
--- a/Dockerfile.remote-cpp-env
+++ b/Dockerfile.remote-cpp-env
@@ -11,10 +11,10 @@
 # ssh credentials (test user):
 #   user@password 
 
-FROM ubuntu:18.04
+FROM ubuntu:latest
 
 RUN apt-get update \
-  && apt-get install -y ssh \
+  && DEBIAN_FRONTEND="noninteractive" apt-get install -y ssh \
       build-essential \
       gcc \
       g++ \


### PR DESCRIPTION
This PR will allow the use of the latest Ubuntu version (which at the moment is 20.04)