### PR TITLE
Correct typo which prevents container from running

### DIFF
--- a/Dockerfile.remote-cpp-env
+++ b/Dockerfile.remote-cpp-env
@@ -2,7 +2,7 @@
 #
 # Build and run:
 #   docker build -t clion/remote-cpp-env:0.5 -f Dockerfile.remote-cpp-env .
-#   docker run -d --cap-add sys_ptrace -p127.0.0.1:2222:22 --name clion_remote_env clion/remote-cpp-env:0.5
+#   docker run -d --cap-add sys_ptrace -p 127.0.0.1:2222:22 --name clion_remote_env clion/remote-cpp-env:0.5
 #   ssh-keygen -f "$HOME/.ssh/known_hosts" -R "[localhost]:2222"
 #
 # stop:


### PR DESCRIPTION
According to this blog post https://blog.jetbrains.com/clion/2020/01/using-docker-with-clion you should copy the first three lines after "Build and run" in the first comment. In the second line is a typo (-p127.0.0.1:2222:22; missing whitespace between "-p" and "127.0.0.1:2222:22), which prevents the container from running, when copying this line.