### PR TITLE
Typo in the run step

### DIFF
--- a/Dockerfile.remote-cpp-env
+++ b/Dockerfile.remote-cpp-env
@@ -2,7 +2,7 @@
 #
 # Build and run:
 #   docker build -t clion/remote-cpp-env:0.5 -f Dockerfile.remote-cpp-env .
-#   docker run -d --cap-add sys_ptrace -p127.0.0.1:2222:22 --name clion_remote_env clion/remote-cpp-env:0.5
+#   docker run -d --cap-add sys_ptrace -p 127.0.0.1:2222:22 --name clion_remote_env clion/remote-cpp-env:0.5
 #   ssh-keygen -f "$HOME/.ssh/known_hosts" -R "[localhost]:2222"
 #
 # stop:


### PR DESCRIPTION
There is a space missing after the -p argument.