### PR TITLE
Caps cap

### DIFF
--- a/Dockerfile.remote-cpp-env
+++ b/Dockerfile.remote-cpp-env
@@ -2,7 +2,7 @@
 #
 # Build and run:
 #   docker build -t clion/remote-cpp-env:0.5 -f Dockerfile.remote-cpp-env .
-#   docker run -d --cap-add sys_ptrace -p 127.0.0.1:2222:22 --name clion_remote_env clion/remote-cpp-env:0.5
+#   docker run -d --cap-add SYS_PTRACE -p 127.0.0.1:2222:22 --name clion_remote_env clion/remote-cpp-env:0.5
 #   ssh-keygen -f "$HOME/.ssh/known_hosts" -R "[localhost]:2222"
 #
 # stop:


### PR DESCRIPTION
Although the provided docker command is valid:
```bash
docker run -d --cap-add sys_ptrace -p 127.0.0.1:2222:22 --name clion_remote_env clion/remote-cpp-env:0.5
```
running the option `--cap-add sys_ptrace` in CLion "Run/Debug Configurations" raises the error:
```
Failed to deploy '<container name> Image id: <image name>': No enum constant com.github.dockerjava.api.model.Capability.sys_ptrace
```
![image](https://github.com/JetBrains/clion-remote/assets/127103512/c64eca5a-27b0-488d-800e-3d979e93a6bb)

`--cap-add SYS_PTRACE` is valid both in docker CLI and CLion IDE.